### PR TITLE
Ajout de la propriété "env_file" au service "worker" (Docker)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     restart: always
     environment:
       REDIS_URL: redis://redis
+    env_file:
+      - .env
     depends_on:
       - redis
     networks:


### PR DESCRIPTION
Le worker ne pouvait pas accéder au fichier uploadé dans le storage S3.

- Ajout de :
```yaml
    env_file:
      - .env
```

dans le fichier `docker-compose.yaml`